### PR TITLE
fix AnimatePresence type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loofkid/svelte-motion",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Svelte animation library based on the React library framer-motion.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@loofkid/svelte-motion",
-  "version": "0.11.6",
+  "name": "svelte-motion",
+  "version": "0.11.5",
   "description": "Svelte animation library based on the React library framer-motion.",
   "main": "src/index.js",
   "scripts": {

--- a/types/components/AnimatePresence/index.d.ts
+++ b/types/components/AnimatePresence/index.d.ts
@@ -42,4 +42,5 @@ import { AnimatePresenceProps } from "./types";
  *
  * @public
  */
-export declare class AnimatePresence<T extends {key:any}> extends SvelteComponentTyped<AnimatePresenceProps<T>, {}, {default:{ item: T | { key: 1} }}> {}
+type ConditionalGeneric<T> = T extends {key:any} ? T : { key: 1};
+export declare class AnimatePresence<T extends {key:any}> extends SvelteComponentTyped<AnimatePresenceProps<T>, {}, {default:{ item: ConditionalGeneric<T> }}> {}

--- a/types/components/AnimatePresence/index.d.ts
+++ b/types/components/AnimatePresence/index.d.ts
@@ -42,5 +42,5 @@ import { AnimatePresenceProps } from "./types";
  *
  * @public
  */
-type ConditionalGeneric<T> = T extends {key:any} ? T : { key: 1};
-export declare class AnimatePresence<T extends {key:any}> extends SvelteComponentTyped<AnimatePresenceProps<T>, {}, {default:{ item: ConditionalGeneric<T> }}> {}
+type ConditionalGeneric<T> = T extends {key:any} ? T : { key: 1}; // Better handling of defaults and the optional list prop
+export declare type AnimatePresence<T extends {key:any}> = SvelteComponentTyped<AnimatePresenceProps<T>, {}, {default:{ item: ConditionalGeneric<T> }}> 

--- a/types/components/AnimatePresence/index.d.ts
+++ b/types/components/AnimatePresence/index.d.ts
@@ -42,4 +42,4 @@ import { AnimatePresenceProps } from "./types";
  *
  * @public
  */
-export declare type AnimatePresence<T extends {key:any}> = SvelteComponentTyped<AnimatePresenceProps<T>, {}, {default:{ item: T | { key: 1} }}> 
+export declare class AnimatePresence<T extends {key:any}> extends SvelteComponentTyped<AnimatePresenceProps<T>, {}, {default:{ item: T | { key: 1} }}> {}


### PR DESCRIPTION
Declaring as type causes import errors - either there's an error importing or an error using. Exporting as a class fixes this.